### PR TITLE
Refactor: 시험지 페이지 스타일 조정 및 API연동

### DIFF
--- a/pages/mypage/[id].jsx
+++ b/pages/mypage/[id].jsx
@@ -1,22 +1,31 @@
-import axios from 'axios';
 import React from 'react';
 import { useRouter } from 'next/router';
 import MyTestPaper from '../../src/components/MyTestPaper';
 import { Button } from '@mui/material';
+import Container from '../../src/components/common/Container';
 
 const MyTestPage = () => {
   const router = useRouter();
+
   return (
-    <>
+    <Container bgColor={'#F8F0E9'}>
       <MyTestPaper />
       <Button
         fullWidth
-        sx={{ mt: 6, height: 56 }}
+        variant="contained"
+        sx={{
+          mt: 6,
+          height: 56,
+          backgroundColor: '#015B30',
+          '&:hover': {
+            backgroundColor: '#015B30',
+          },
+        }}
         onClick={() => router.back()}
       >
         닫기
       </Button>
-    </>
+    </Container>
   );
 };
 

--- a/pages/write/[id]/end.jsx
+++ b/pages/write/[id]/end.jsx
@@ -1,8 +1,12 @@
 import React from 'react';
 import WriteEndPaper from '../../../src/components/WriteEndPaper';
-
+import Container from '../../../src/components/common/Container';
 const WriteEndPage = () => {
-  return <WriteEndPaper />;
+  return (
+    <Container bgColor={'#F8F0E9'}>
+      <WriteEndPaper />
+    </Container>
+  );
 };
 
 export default WriteEndPage;

--- a/pages/write/[id]/index.jsx
+++ b/pages/write/[id]/index.jsx
@@ -1,8 +1,12 @@
 import React from 'react';
 import WritePaper from '../../../src/components/WritePaper';
-
+import Container from '../../../src/components/common/Container';
 const WritePage = () => {
-  return <WritePaper />;
+  return (
+    <Container bgColor={'#F8F0E9'}>
+      <WritePaper />
+    </Container>
+  );
 };
 
 export default WritePage;

--- a/src/components/MyTestPaper/index.jsx
+++ b/src/components/MyTestPaper/index.jsx
@@ -1,64 +1,68 @@
 import React, { useState, useEffect } from 'react';
-import PropTypes from 'prop-types';
+import TotalScore from '../common/TotalScore';
 import { useRouter } from 'next/router';
-import {
-  Divider,
-  Typography,
-  Box,
-  List,
-  ListItem,
-  Avatar,
-} from '@mui/material';
-import { getDate, getStamp } from '../../utils';
+import { Divider, Typography, Box, List, ListItem } from '@mui/material';
+import { getDate } from '../../utils';
 import Image from 'next/image';
+import axios from 'axios';
 
 const MyTestPaper = () => {
   const router = useRouter();
-  const [testData, setTestData] = useState(null);
+  const [testData, setTestData] = useState({
+    answer_user: [],
+    created_at: '',
+    is_correct_list: [],
+    score: 0,
+    username: '',
+    answer: [],
+  });
 
   useEffect(() => {
     if (!router) return;
-    if (!testData) return;
 
     const fetchData = async () => {
       try {
+        //userId와 paperId
         const { data } = await axios({
           baseURL: API_DOMAIN,
-          url: `papers/get_paper_detail/2/6/`,
+          url: `/papers/get_paper_detail/6/1/`,
           method: 'get',
         });
-
         setTestData(data);
-      } catch (e) {}
+      } catch (e) {
+        console.log(e);
+      }
     };
 
     fetchData();
-  }, []);
+  }, [router.query.id]);
 
-  if (!router || !testData) return null;
+  if (!router) return null;
 
   return (
     <>
-      <Typography variant="h5" mb="17px">
-        제 {router.query.id}회 받아쓰기
-      </Typography>
-      <Box sx={{ display: 'flex', alignItems: 'center' }}>
+      <Box sx={{ display: 'flex', width: '100%', alignItems: 'center' }}>
+        <Typography variant="h3" mb="17px">
+          제 {router.query.id}회 받아쓰기
+        </Typography>
+      </Box>
+      <Box sx={{ display: 'flex', width: '100%', alignItems: 'center' }}>
         <Image src="/image/paper/date.png" alt="날짜" width={31} height={18} />
         <Typography ml={2} component="span" varaint="body1">
-          {getDate(testData?.date)}
+          {getDate(testData.created_at)}
         </Typography>
       </Box>
       <Divider mb="4px" />
-      <Box mb={2} sx={{ display: 'flex', alignItems: 'center' }}>
+      <Box mb={2} sx={{ display: 'flex', width: '100%', alignItems: 'center' }}>
         <Image src="/image/paper/name.png" alt="이름" width={31} height={18} />
         <Typography component="span" ml={2} varaint="body1">
-          {testData?.username}
+          {testData.username}
         </Typography>
       </Box>
       <Divider />
       <List disablePadding sx={{ width: '100%', border: '1px solid' }}>
-        {testData?.is_correct_list &&
-          testData?.is_correct_list.map((isCorrect, i) => {
+        {testData.is_correct_list.length &&
+          testData.is_correct_list.map((isCorrect, i) => {
             return (
               <React.Fragment key={i}>
                 <ListItem
@@ -86,11 +90,11 @@ const MyTestPaper = () => {
                     }}
                   >
                     <Typography component="div" variant="body2">
-                      {testData?.answer_user[i]}
+                      {testData.answer_user[i]}
                     </Typography>
                     {!isCorrect && (
                       <Typography component="div" variant="body2" color="red">
-                        {testData?.answer[i]}
+                        {testData.answer[i]}
                       </Typography>
                     )}
                   </Box>
@@ -99,42 +103,7 @@ const MyTestPaper = () => {
               </React.Fragment>
             );
           })}
-        <ListItem
-          disablePadding
-          sx={{
-            pt: '18px',
-            pl: '18px',
-            height: 116,
-            alignItems: 'flex-start',
-          }}
-        >
-          <Image
-            src="/image/paper/totalScore.png"
-            alt="totalScore"
-            width={31}
-            height={18}
-          />
-          <Box ml={5}>
-            <Typography variant="h2" color="red">
-              {testData?.problems[0]}
-            </Typography>
-            <Image
-              width={74}
-              height={26}
-              src="/image/paper/scoreUnderline.png"
-              alt="scoreUnderline"
-            />
-          </Box>
-          <Avatar
-            src={`/image/paper/${getStamp(score)}.png`}
-            alt="stamp"
-            sx={{
-              ml: 7,
-              width: 96,
-              height: 96,
-            }}
-          />
-        </ListItem>
+        <TotalScore score={testData.score} />
       </List>
     </>
   );

--- a/src/components/WriteEndPaper/TestEndList/index.jsx
+++ b/src/components/WriteEndPaper/TestEndList/index.jsx
@@ -10,7 +10,7 @@ import React from 'react';
 import Image from 'next/image';
 import { useRecoilValue } from 'recoil';
 import { ProblemsState } from '../../../store/atoms';
-import { getStamp } from '../../../utils';
+import TotalScore from '../../common/TotalScore';
 
 const TestEndList = () => {
   const problems = useRecoilValue(ProblemsState);
@@ -50,9 +50,9 @@ const TestEndList = () => {
                   <Typography component="div" variant="body2">
                     {problem.input}
                   </Typography>
-                  {problems.answer && (
+                  {problem.answer && (
                     <Typography component="div" variant="body2" color="red">
-                      {problems.answer}
+                      {problem.answer}
                     </Typography>
                   )}
                 </Box>
@@ -61,44 +61,7 @@ const TestEndList = () => {
             </React.Fragment>
           );
         })}
-        <ListItem
-          disablePadding
-          sx={{
-            pt: '18px',
-            pl: '18px',
-            height: 116,
-            alignItems: 'flex-start',
-          }}
-        >
-          <Image
-            src="/image/paper/totalScore.png"
-            alt="totalScore"
-            width={31}
-            height={18}
-          />
-          <Box ml={5}>
-            <Typography variant="h2" color="red">
-              {problems[0]}
-            </Typography>
-            <Image
-              width={74}
-              height={26}
-              src="/image/paper/scoreUnderline.png"
-              alt="scoreUnderline"
-            />
-          </Box>
-          {problems[0] && (
-            <Avatar
-              src={`/image/paper/${getStamp(problems[0])}.png`}
-              alt="stamp"
-              sx={{
-                ml: 7,
-                width: 96,
-                height: 96,
-              }}
-            />
-          )}
-        </ListItem>
+        <TotalScore score={problems[0]} />
       </List>
     </>
   );

--- a/src/components/WriteEndPaper/index.jsx
+++ b/src/components/WriteEndPaper/index.jsx
@@ -32,7 +32,13 @@ const WriteEndPaper = () => {
             component="a"
             fullWidth
             variant="contained"
-            sx={{ height: 56 }}
+            sx={{
+              height: 56,
+              backgroundColor: '#015B30',
+              '&:hover': {
+                backgroundColor: '#015B30',
+              },
+            }}
             onClick={goMyPage}
           >
             생활기록부 보기
@@ -42,7 +48,13 @@ const WriteEndPaper = () => {
           <Button
             fullWidth
             variant="contained"
-            sx={{ height: 56 }}
+            sx={{
+              height: 56,
+              backgroundColor: '#015B30',
+              '&:hover': {
+                backgroundColor: '#015B30',
+              },
+            }}
             onClick={goTesting}
           >
             다른 시험 보기

--- a/src/components/WritePaper/index.jsx
+++ b/src/components/WritePaper/index.jsx
@@ -6,6 +6,7 @@ import { useRecoilState } from 'recoil';
 import { problemsInitialState, ProblemsState } from '../../store/atoms';
 import { Box, Button } from '@mui/material';
 import axios from 'axios';
+import next from 'next';
 
 const WritePaper = () => {
   const router = useRouter();
@@ -17,11 +18,10 @@ const WritePaper = () => {
     const [score, ...inputs] = problems;
     const answer = [...inputs].map((input) => input.input);
     const requestData = {
-      user: 1,
-      paper: 3,
+      user_id: 6,
+      paper_id: router.query.id,
       answer,
     };
-    console.log(requestData);
 
     try {
       const { data } = await axios({
@@ -30,12 +30,17 @@ const WritePaper = () => {
         method: 'post',
         data: requestData,
       });
-      console.log(data);
+      const nextState = data.answer.map((resAnswer, i) => {
+        if (data.is_correct[i]) {
+          return { input: answer[i], answer: inputs[i + 1].answer };
+        }
+        return { input: answer[i], answer: resAnswer };
+      });
+      setProblems([data.score, ...nextState]);
+      router.push(`/write/${router.query.id}/end`);
     } catch (e) {
       console.log('error', e);
     }
-    // 이동 잘되는 지 확인하기
-    // router.push(`/write/${router.query.id}/end`);
   };
 
   const moveMainPage = () => {
@@ -49,17 +54,33 @@ const WritePaper = () => {
     <>
       <WriteTitle />
       <TestList />
-      <Box>
+      <Box sx={{ width: '100%', mt: '31px' }}>
         <Button
           component="a"
           fullWidth
           variant="contained"
-          sx={{ height: 56 }}
+          sx={{
+            height: 56,
+            backgroundColor: '#015B30',
+            '&:hover': {
+              backgroundColor: '#015B30',
+            },
+          }}
           onClick={handleSubmit}
         >
           다 풀었어요
         </Button>
-        <Button fullWidth sx={{ height: 56 }} onClick={moveMainPage}>
+        <Button
+          fullWidth
+          sx={{
+            height: 56,
+            color: '#015B30',
+            '&:hover': {
+              color: '#015B30',
+            },
+          }}
+          onClick={moveMainPage}
+        >
           다음에 풀기
         </Button>
       </Box>

--- a/src/components/common/TotalScore.jsx
+++ b/src/components/common/TotalScore.jsx
@@ -1,0 +1,57 @@
+import { Avatar, ListItem, Typography } from '@mui/material';
+import { Box } from '@mui/system';
+import Image from 'next/image';
+import React from 'react';
+import PropTypes from 'prop-types';
+import { getStamp } from '../../utils';
+
+const TotalScore = ({ score }) => {
+  return (
+    <ListItem
+      disablePadding
+      sx={{
+        pl: '18px',
+        height: 116,
+        alignItems: 'flex-start',
+      }}
+    >
+      <Box mt="18px">
+        <Image
+          src="/image/paper/totalScore.png"
+          alt="totalScore"
+          width={31}
+          height={18}
+        />
+      </Box>
+      <Box ml={5} mt={1}>
+        <Typography variant="h2" color="red" align="center">
+          {score}
+        </Typography>
+        <Image
+          width={74}
+          height={26}
+          src="/image/paper/scoreUnderline.png"
+          alt="scoreUnderline"
+        />
+      </Box>
+      {score >= 0 && (
+        <Avatar
+          src={`/image/paper/${getStamp(score)}.png`}
+          alt="stamp"
+          sx={{
+            mt: 1,
+            ml: 7,
+            width: 96,
+            height: 96,
+          }}
+        />
+      )}
+    </ListItem>
+  );
+};
+
+TotalScore.propTypes = {
+  score: PropTypes.number,
+};
+
+export default TotalScore;

--- a/src/components/common/WriteTitle.jsx
+++ b/src/components/common/WriteTitle.jsx
@@ -11,17 +11,19 @@ const WriteTitle = () => {
 
   return (
     <>
-      <Typography variant="h5" mb="17px">
-        제 {router.query.id}회 받아쓰기
-      </Typography>
-      <Box sx={{ display: 'flex', alignItems: 'center' }}>
+      <Box sx={{ display: 'flex', width: '100%', alignItems: 'center' }}>
+        <Typography component="h2" variant="h3" mb="17px">
+          제 {router.query.id}회 받아쓰기
+        </Typography>
+      </Box>
+      <Box sx={{ display: 'flex', width: '100%', alignItems: 'center' }}>
         <Image src="/image/paper/date.png" alt="날짜" width={31} height={18} />
         <Typography ml={2} component="span" varaint="body1">
           {getDate()}
         </Typography>
       </Box>
       <Divider mb="4px" />
-      <Box mb={2} sx={{ display: 'flex', alignItems: 'center' }}>
+      <Box mb={2} sx={{ display: 'flex', width: '100%', alignItems: 'center' }}>
         <Image src="/image/paper/name.png" alt="이름" width={31} height={18} />
         <Typography component="span" ml={2} varaint="body1">
           이름

--- a/src/store/atoms.js
+++ b/src/store/atoms.js
@@ -9,15 +9,6 @@ export const problemsInitialState = [
   { input: '', answer: '' },
 ];
 
-const mockData = [
-  40,
-  { input: '', answer: '안녕' },
-  { input: '', answer: '하이' },
-  { input: '', answer: '바이' },
-  { input: '', answer: '' },
-  { input: '', answer: '' },
-];
-
 export const ProblemsState = atom({
   key: 'ProblomsState',
   default: problemsInitialState,

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,20 +1,22 @@
 export const getStamp = (scoreAny) => {
   const score = Number(scoreAny);
-
+  console.log(score);
   if (score >= 80) {
     return 'Good';
   } else if (score >= 60) {
     return 'Soso';
-  } else {
-    return 'Bad';
   }
+
+  return 'Bad';
 };
 
 export const getDate = (inputDate) => {
-  const date = inputDate ? new Date(inputDate) : new Date();
+  let date = new Date();
+  if (inputDate) date = new Date(inputDate);
+
   const year = date.getFullYear();
-  const month = date.getMonth();
-  const day = date.getDay();
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
 
   return `${year}년 ${month}월 ${day}일`;
 };


### PR DESCRIPTION
## 구현내용

### 시험보기
![image](https://user-images.githubusercontent.com/63578094/156893571-9a4922eb-542c-48cf-b261-de5b24711e52.png)

### 시험결과보기
![image](https://user-images.githubusercontent.com/63578094/156893584-9d8527bf-1fbc-46ab-b2fb-c108bd06fb16.png)

### 내가 푼 시험지 풀기
![image](https://user-images.githubusercontent.com/63578094/156893556-f4cc89ac-a9ac-4894-b3be-244403c6fef2.png)

1. userId와 username부분만 연동하면 돼서 그 부분은 주석으로 처리